### PR TITLE
default join URL, AWARE libs version, git hash in version_readable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,8 +50,8 @@ configurations.all {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.github.denzilferreira:aware-client:$aware_libs"
-//    compile ("com.github.CxAalto:aware-client:nima5-SNAPSHOT")
+//    compile "com.github.denzilferreira:aware-client:$aware_libs"
+    compile ("com.github.CxAalto:aware-client:HYKS-live-SNAPSHOT")
 //            {
 //        exclude(group: "com.awareframework", module:"aware-core")
 //    }

--- a/app/src/main/java/com/aware/plugin/hyks/HYKS.java
+++ b/app/src/main/java/com/aware/plugin/hyks/HYKS.java
@@ -88,6 +88,16 @@ public class HYKS extends AppCompatActivity {
 
                     EditText edittext_study_url = (EditText) findViewById(R.id.edittext_study_url);
                     String url = String.valueOf(edittext_study_url.getText());
+                    if (url.length() < 20) {
+                        if (!url.matches("[0-9a-f]{16}")) {
+                            Toast toast = Toast.makeText(getApplicationContext(),
+                                    "Join must be either URL or 16-digit secret ID",
+                                    Toast.LENGTH_LONG);
+                            toast.show();
+                            return;
+                        }
+                        url = "https://aware.koota.zgib.net/index.php/aware/v1/" + url + "?crt_sha256=436669a4920ac08623357aaca77c935bbc3bf3906a9c962eb822edff021fcc42&crt_url=https%3A%2F%2Fdata.koota.cs.aalto.fi%2Fstatic%2Fserver-aware.crt";
+                    }
                     Aware.joinStudy(getApplicationContext(), url);
 
                     Aware.setSetting(getApplicationContext(), Aware_Preferences.STATUS_ESM, true);

--- a/app/src/main/res/layout/main_ui.xml
+++ b/app/src/main/res/layout/main_ui.xml
@@ -30,10 +30,11 @@
     <EditText
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="https://api.awareframework.com/index.php/webservice/index/123/123456789"
+        android:text="NNNNNNNNNNNNNNNN"
         android:ems="10"
         android:id="@+id/edittext_study_url"
         android:inputType="textUri" />
+<!--        android:text="https://api.awareframework.com/index.php/webservice/index/123/123456789"-->
 
     <Button
         android:id="@+id/join_study"

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+
+def currentGit = "git -C ${rootDir} describe --long --always --dirty".execute().text.trim()
+
 project.ext {
     support_libs = (System.getenv("support_libs") as String ?: "25.1.0")
     google_libs = (System.getenv("google_libs") as String ?: "10.0.1")
     version_code = 400 + (System.getenv("BUILD_NUMBER") as Integer ?: 0)
-    version_readable = "4.0." + version_code
+    version_readable = "4.0." + version_code + "." + currentGit
     aware_libs = (System.getenv("aware_libs") as String ?: "master-SNAPSHOT")
 }
 


### PR DESCRIPTION
* Several changes over the last bit:
** Added a default URL.  Now you can enter only the device secret ID and it will fill in the rest of the URL
** Update to AWARE libs version, branch HYKS-live.  This can be updated as needed.
** Add the current git hash to version name