### PR TITLE
Change ambient noise plugin version to fix build error

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,7 +58,7 @@ dependencies {
 
     compile "com.android.support:appcompat-v7:$support_libs"
 //    compile "com.github.denzilferreira:com.aware.plugin.ambient_noise:$aware_libs"
-    compile "com.github.rkdarst:com.aware.plugin.ambient_noise:no-raw-data-SNAPSHOT"
+    compile "com.github.rkdarst:com.aware.plugin.ambient_noise:HYKS-live-SNAPSHOT"
 
     compile 'joda-time:joda-time:2.9.6'
     compile 'com.squareup.okhttp3:okhttp:3.4.2'


### PR DESCRIPTION
- The ambient noise plugin was using denzilferreira/aware-client for
  the aware libs, and this app used CxAalto/aware-client.  I think
  this was a problem, so changed the libs in the ambient noise plugin
  (CxAalto version - since denzil hasn't pulled the change yet), and
  thus we have this.